### PR TITLE
Fix websocket error on dev environment

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -60,6 +60,7 @@ source 'https://rails-assets.org' do
 end
 
 group :development do
+  gem 'puma'
   gem 'quiet_assets'
   gem 'capistrano'
   gem 'capistrano-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -310,6 +310,7 @@ GEM
     pry-remote (0.1.8)
       pry (~> 0.9)
       slop (~> 3.0)
+    puma (3.4.0)
     quiet_assets (1.1.0)
       railties (>= 3.1, < 5.0)
     rack (1.6.4)
@@ -562,6 +563,7 @@ DEPENDENCIES
   postmark-rails
   pry
   pry-remote
+  puma
   quiet_assets
   rack-attack
   rails (= 4.2.6)


### PR DESCRIPTION
Because faye-websocket-ruby gem requires direct access to TCP which
WEBrick cannot provide, running application on dev environemnt caused
multiple occurences of:

```
NotImplementedError (only partial hijack is supported.):
  rack (1.6.4) lib/rack/handler/webrick.rb:76:in `block in service'
  faye-websocket (0.10.4) lib/faye/rack_stream.rb:33:in `hijack_rack_socket'
  faye-websocket (0.10.4) lib/faye/rack_stream.rb:25:in `initialize'
  faye-websocket (0.10.4) lib/faye/websocket.rb:77:in `new'
  faye-websocket (0.10.4) lib/faye/websocket.rb:77:in `initialize'
  /Users/lokson/.rvm/gems/ruby-2.3.1@kanban_on_rails/bundler/gems/actioncable-265535ce9340/lib/action_cable/connection/web_socket.rb:10:in `new'
  /Users/lokson/.rvm/gems/ruby-2.3.1@kanban_on_rails/bundler/gems/actioncable-265535ce9340/lib/action_cable/connection/web_socket.rb:10:in `initialize'
  /Users/lokson/.rvm/gems/ruby-2.3.1@kanban_on_rails/bundler/gems/actioncable-265535ce9340/lib/action_cable/connection/base.rb:61:in `new'
  /Users/lokson/.rvm/gems/ruby-2.3.1@kanban_on_rails/bundler/gems/actioncable-265535ce9340/lib/action_cable/connection/base.rb:61:in `initialize'
  /Users/lokson/.rvm/gems/ruby-2.3.1@kanban_on_rails/bundler/gems/actioncable-265535ce9340/lib/action_cable/server/base.rb:24:in `new'
  /Users/lokson/.rvm/gems/ruby-2.3.1@kanban_on_rails/bundler/gems/actioncable-265535ce9340/lib/action_cable/server/base.rb:24:in `call'
  actionpack (4.2.6) lib/action_dispatch/routing/mapper.rb:51:in `serve'
  actionpack (4.2.6) lib/action_dispatch/journey/router.rb:43:in `block in serve'
  actionpack (4.2.6) lib/action_dispatch/journey/router.rb:30:in `each'
  actionpack (4.2.6) lib/action_dispatch/journey/router.rb:30:in `serve'
  actionpack (4.2.6) lib/action_dispatch/routing/route_set.rb:817:in `call'
  omniauth (1.3.1) lib/omniauth/strategy.rb:186:in `call!'
  omniauth (1.3.1) lib/omniauth/strategy.rb:164:in `call'
  omniauth (1.3.1) lib/omniauth/strategy.rb:186:in `call!'
  omniauth (1.3.1) lib/omniauth/strategy.rb:164:in `call'
  omniauth (1.3.1) lib/omniauth/strategy.rb:186:in `call!'
  omniauth (1.3.1) lib/omniauth/strategy.rb:164:in `call'
  bullet (5.1.0) lib/bullet/rack.rb:12:in `call'
  http_accept_language (2.0.5) lib/http_accept_language/middleware.rb:14:in `call'
  rack-attack (4.4.1) lib/rack/attack.rb:107:in `call'
  warden (1.2.6) lib/warden/manager.rb:35:in `block in call'
  warden (1.2.6) lib/warden/manager.rb:34:in `catch'
  warden (1.2.6) lib/warden/manager.rb:34:in `call'
  rack (1.6.4) lib/rack/etag.rb:24:in `call'
  rack (1.6.4) lib/rack/conditionalget.rb:25:in `call'
  rack (1.6.4) lib/rack/head.rb:13:in `call'
  actionpack (4.2.6) lib/action_dispatch/middleware/params_parser.rb:27:in `call'
  actionpack (4.2.6) lib/action_dispatch/middleware/flash.rb:260:in `call'
  rack (1.6.4) lib/rack/session/abstract/id.rb:225:in `context'
  rack (1.6.4) lib/rack/session/abstract/id.rb:220:in `call'
  actionpack (4.2.6) lib/action_dispatch/middleware/cookies.rb:560:in `call'
  activerecord (4.2.6) lib/active_record/query_cache.rb:36:in `call'
  activerecord (4.2.6) lib/active_record/connection_adapters/abstract/connection_pool.rb:653:in `call'
  activerecord (4.2.6) lib/active_record/migration.rb:377:in `call'
  actionpack (4.2.6) lib/action_dispatch/middleware/callbacks.rb:29:in `block in call'
  activesupport (4.2.6) lib/active_support/callbacks.rb:88:in `__run_callbacks__'
  activesupport (4.2.6) lib/active_support/callbacks.rb:778:in `_run_call_callbacks'
  activesupport (4.2.6) lib/active_support/callbacks.rb:81:in `run_callbacks'
  actionpack (4.2.6) lib/action_dispatch/middleware/callbacks.rb:27:in `call'
  actionpack (4.2.6) lib/action_dispatch/middleware/reloader.rb:73:in `call'
  actionpack (4.2.6) lib/action_dispatch/middleware/remote_ip.rb:78:in `call'
  actionpack (4.2.6) lib/action_dispatch/middleware/debug_exceptions.rb:17:in `call'
  actionpack (4.2.6) lib/action_dispatch/middleware/show_exceptions.rb:30:in `call'
  railties (4.2.6) lib/rails/rack/logger.rb:38:in `call_app'
  railties (4.2.6) lib/rails/rack/logger.rb:20:in `block in call'
  activesupport (4.2.6) lib/active_support/tagged_logging.rb:68:in `block in tagged'
  activesupport (4.2.6) lib/active_support/tagged_logging.rb:26:in `tagged'
  activesupport (4.2.6) lib/active_support/tagged_logging.rb:68:in `tagged'
  railties (4.2.6) lib/rails/rack/logger.rb:20:in `call'
  quiet_assets (1.1.0) lib/quiet_assets.rb:27:in `call_with_quiet_assets'
  actionpack (4.2.6) lib/action_dispatch/middleware/request_id.rb:21:in `call'
  rack (1.6.4) lib/rack/methodoverride.rb:22:in `call'
  rack (1.6.4) lib/rack/runtime.rb:18:in `call'
  activesupport (4.2.6) lib/active_support/cache/strategy/local_cache_middleware.rb:28:in `call'
  actionpack (4.2.6) lib/action_dispatch/middleware/static.rb:120:in `call'
  rack (1.6.4) lib/rack/sendfile.rb:113:in `call'
  railties (4.2.6) lib/rails/engine.rb:518:in `call'
  railties (4.2.6) lib/rails/application.rb:165:in `call'
  rack (1.6.4) lib/rack/lock.rb:17:in `call'
  rack (1.6.4) lib/rack/content_length.rb:15:in `call'
  rack (1.6.4) lib/rack/handler/webrick.rb:88:in `service'
  /Users/lokson/.rvm/rubies/ruby-2.3.1/lib/ruby/2.3.0/webrick/httpserver.rb:140:in `service'
  /Users/lokson/.rvm/rubies/ruby-2.3.1/lib/ruby/2.3.0/webrick/httpserver.rb:96:in `run'
  /Users/lokson/.rvm/rubies/ruby-2.3.1/lib/ruby/2.3.0/webrick/server.rb:296:in `block in start_thread'
```

This merge pull changes dev server to Puma. No configuraion is needed,
just bundle install, start with `rails c` and those errors are gone.

Based on: https://github.com/faye/faye-websocket-ruby/issues/56