### PR TITLE
Fix new issue on issue edit

### DIFF
--- a/app/views/issues/new.js.erb
+++ b/app/views/issues/new.js.erb
@@ -1,4 +1,4 @@
-$('#issue_form').replaceWith('<%= j render 'form', :issue => @issue, :project => @project, :remote => true %>');
+$('#issue_modal #issue_form').replaceWith('<%= j render 'form', :issue => @issue, :project => @project, :remote => true %>');
 
 if (($('#issue_modal').data('bs.modal') || { isShown: false }).isShown == false) {
   $('#issue_modal').modal('show');


### PR DESCRIPTION
While user was editing an issue (http://localhost:3000/users/1/issues)
if add issue button was pressed (on top bar) an empty modal was shown,
while edit form was changed to be a new issue form.

This pull request ensures that a new issue form will be rendered always
in the modal.