### PR TITLE
Create ability to automatically generate changelogs

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -50,7 +50,7 @@ Metrics/LineLength:
   Max: 115
 
 Metrics/ClassLength:
-  Max: 200
+  Max: 250
 
 Style/Documentation:
   Enabled: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -22,7 +22,7 @@ GIT
 
 GIT
   remote: https://github.com/technoeleganceteam/bitbucket.git
-  revision: 503ae118bb06bd5f7f07dd19385f93bbfab689d5
+  revision: 6b907341d927f3d0019d012968bd63e943c6bcca
   specs:
     bitbucket_rest_api (0.1.7)
       faraday (~> 0.9.0)

--- a/app/assets/javascripts/shared.coffee
+++ b/app/assets/javascripts/shared.coffee
@@ -47,18 +47,27 @@ close_issue = (project_id, issue_id) ->
 
 window.init_tags = ->
   $('.column_tags').select2
+    width: '100%'
     placeholder: window.i18n_column_tags
     tags: true
 
   $('.section_tags').select2
+    width: '100%'
     placeholder: window.i18n_section_tags
     tags: true
 
   $('.issue_tags').select2
+    width: '100%'
     placeholder: window.i18n_issue_tags
     tags: true
 
+  $('.emails_for_reports').select2
+    width: '100%'
+    placeholder: window.i18n_emails_for_reports
+    tags: true
+
   $('.issue_project').select2
+    width: '100%'
     tags: true
     ajax:
       url: Routes.user_projects_path(window.current_user_id)
@@ -76,6 +85,7 @@ window.init_tags = ->
 
   $('.user_projects').select2
     tags: true
+    width: '100%'
     ajax:
       url: Routes.user_projects_path(window.current_user_id)
       dataType: 'json'

--- a/app/assets/stylesheets/customized.sass
+++ b/app/assets/stylesheets/customized.sass
@@ -5,7 +5,7 @@ body
   overflow-y: scroll
   overflow: -moz-scrollbars-vertical
 
-.select2-container
+.select2-search--inline
   width: 100% !important
 
 .select2-search__field

--- a/app/controllers/changelogs_controller.rb
+++ b/app/controllers/changelogs_controller.rb
@@ -1,0 +1,32 @@
+class ChangelogsController < ApplicationController
+  load_and_authorize_resource :project
+
+  load_and_authorize_resource :changelog, :through => :project
+
+  def index
+    @changelogs = @project.changelogs.order('last_commit_date DESC').page(params[:page])
+  end
+
+  def show
+    respond_to do |format|
+      format.text do
+        render :partial => 'changelogs/changelog_raw_md', :collection => [@changelog], :layout => false,
+          :formats => [:html], :as => :changelog
+      end
+
+      format.html { render }
+    end
+  end
+
+  def resend
+    ProjectMailer.changelogs_email([@changelog.id]).deliver_later if @project.emails_for_reports.any?
+
+    redirect_to project_changelogs_url, :flash => { :notice => I18n.t('changelog_has_been_resent') }
+  end
+
+  def sync
+    GenerateChangelogWorker.perform_async(@project)
+
+    redirect_to project_changelogs_url, :flash => { :notice => I18n.t('changelogs_has_been_synced') }
+  end
+end

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -43,14 +43,14 @@ class ProjectsController < ApplicationController
       (render :status => 422, :nothing => true) && return
     end
 
-    @project.parse_issue_params_from_github_webhook(params[:issue]) if params[:issue].present?
+    @project.parse_params_from_github_webhook(params)
 
     (render :status => 200, :nothing => true) && return
   end
 
   def payload_from_bitbucket
     if params[:secure_token] == @project.bitbucket_secret_token_for_hook
-      @project.parse_issue_params_from_bitbucket_webhook(params[:issue]) if params[:issue].present?
+      @project.parse_params_from_bitbucket_webhook(params)
     end
 
     render :status => 200, :nothing => true
@@ -58,9 +58,7 @@ class ProjectsController < ApplicationController
 
   def payload_from_gitlab
     if params[:secure_token] == @project.gitlab_secret_token_for_hook
-      if params[:object_attributes].present?
-        @project.parse_issue_params_from_gitlab_webhook(params[:object_attributes])
-      end
+      @project.parse_params_from_gitlab_webhook(params)
     end
 
     render :status => 200, :nothing => true
@@ -95,7 +93,9 @@ class ProjectsController < ApplicationController
   private
 
   def project_params
-    params.require(:project).permit(:name)
+    params.require(:project).permit(:name, :include_issues, :include_pull_requests, :changelog_locale,
+      :generate_changelogs, :close_issues, :write_changelog_to_repository, :changelog_filename,
+      :include_detailed_changes, :emails_for_reports => [])
   end
 
   def assign_owner

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,0 +1,5 @@
+class ApplicationMailer < ActionMailer::Base
+  default :from => Settings.mailer.from_name
+
+  layout 'mailer'
+end

--- a/app/mailers/project_mailer.rb
+++ b/app/mailers/project_mailer.rb
@@ -1,0 +1,31 @@
+class ProjectMailer < ApplicationMailer
+  def changelogs_email(changelog_ids)
+    @changelogs = Changelog.where(:id => changelog_ids).order('last_commit_date DESC')
+
+    return unless @changelogs.any?
+
+    generate_subject
+
+    @changelogs.first.project.emails_for_reports.each do |email|
+      mail(:to => email, :subject => @subject)
+    end
+  end
+
+  private
+
+  def generate_subject
+    @changelogs.reload
+
+    first_changelog = @changelogs.first
+
+    last_changelog = @changelogs.last
+
+    versions = if first_changelog.id == last_changelog.id
+      "#{ t 'release' } #{ first_changelog.tag_name }"
+    else
+      "#{ t 'releases' } #{ last_changelog.tag_name } - #{ first_changelog.tag_name }"
+    end
+
+    @subject = "#{ first_changelog.project.name } #{ versions }"
+  end
+end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -59,6 +59,10 @@ class Ability
         project.user_to_project_connections.find_by(:user_id => user.id, :role => 'owner').present?
       end
 
+      can :manage, Changelog do |changelog|
+        changelog.project.user_ids.include?(user.id)
+      end
+
       can :create, Issue
 
       can :manage, Issue do |issue|

--- a/app/models/board.rb
+++ b/app/models/board.rb
@@ -28,6 +28,9 @@ class Board < ActiveRecord::Base
   validates :column_width, :numericality => { :only_integer => true, :greater_than_or_equal_to => 0,
     :less_than_or_equal_to => Settings.max_column_width }
 
+  validates :column_height, :numericality => { :only_integer => true, :greater_than_or_equal_to => 0,
+    :less_than_or_equal_to => Settings.max_column_height }
+
   validate :column_tags_overlapping
 
   after_update :update_issue_to_section_connections

--- a/app/models/changelog.rb
+++ b/app/models/changelog.rb
@@ -1,0 +1,24 @@
+class Changelog < ActiveRecord::Base
+  belongs_to :project
+
+  has_many :pull_requests, :dependent => :destroy
+
+  has_many :issues
+
+  has_many :pull_request_subtasks
+
+  validates :tag_name, :last_commit_sha, :length => { :maximum => Settings.max_string_field_size },
+    :presence => true
+
+  validates :last_commit_date, :presence => true
+
+  def close_issues
+    pull_requests.map(&:issues).flatten.uniq.each do |issue|
+      next unless issue.provider_id?
+
+      issue.update_attributes(:state => 'closed')
+
+      issue.send("#{ issue.provider }_update_issue", project.send("#{ project.provider }_client_for_changelogs"))
+    end
+  end
+end

--- a/app/models/pull_request.rb
+++ b/app/models/pull_request.rb
@@ -1,0 +1,81 @@
+class PullRequest < ActiveRecord::Base
+  store_accessor :meta, :github_url, :bitbucket_url, :gitlab_url, :author_url, :number_from_provider
+
+  belongs_to :project
+
+  belongs_to :changelog
+
+  has_many :pull_request_subtasks, :dependent => :destroy
+
+  has_many :pull_request_to_issue_connections, :dependent => :destroy
+
+  has_many :issues, :through => :pull_request_to_issue_connections
+
+  after_save :bind_to_issues
+
+  after_save :fetch_or_create_subtasks
+
+  validates :title, :id_from_provider, :length => { :maximum => Settings.max_string_field_size },
+    :presence => true
+
+  validates :merged_at, :presence => true
+
+  def provider
+    Settings.issues_providers.map { |provider| provider if send("#{ provider }_url").present? }.compact.first
+  end
+
+  def url_from_provider
+    send("#{ provider }_url")
+  end
+
+  private
+
+  def bind_to_issues
+    Settings.issue_binding_words.each do |binding_word|
+      body.scan(Regexp.new("#{ binding_word }\\s+\\w*#+\\d+")) do |connection|
+        bind_to_issue(connection.split('#').last)
+      end
+    end
+  end
+
+  def fetch_or_create_subtasks
+    fetched_subtask_ids = body.scan(/^[0-9]*\.*\s*\[\w*\]+.*/).map do |subtask_content|
+      pull_request_subtasks.where(parse_subtask_content(subtask_content)).first_or_create
+    end.compact.map(&:id)
+
+    pull_request_subtasks.where.not(:id => fetched_subtask_ids).destroy_all
+  end
+
+  def parse_subtask_content(subtask_content)
+    {
+      :description => description_from_fetched_data(subtask_content),
+      :story_points => story_points_from_fetched_data(subtask_content),
+      :task_type => task_type_from_fetched_data(subtask_content),
+      :changelog_id => changelog.try(&:id)
+    }
+  end
+
+  def description_from_fetched_data(subtask_content)
+    /[0-9]*\.*\s*(\[\w*\])*(.*)/m.match(subtask_content).try(:[], -1).try(:strip).to_s
+  end
+
+  def story_points_from_fetched_data(subtask_content)
+    subtask_content.scan(/^[0-9]*\.*\s*\[.*\]/m).first.to_s.
+      scan(/\[\w*?\]/).try(:[], 1).to_s.sub(']', '').sub('[', '')
+  end
+
+  def task_type_from_fetched_data(subtask_content)
+    subtask_content.scan(/^[0-9]*\.*\s*\[.*\]/m).first.to_s.
+      scan(/\[\w*?\]/).first.to_s.sub(']', '').sub('[', '')
+  end
+
+  def bind_to_issue(number_from_provider)
+    issue = project.issues.find_by("meta ->> '#{ number_field }' = '?'", number_from_provider.to_i)
+
+    pull_request_to_issue_connections.where(:issue => issue).first_or_create! if issue.present?
+  end
+
+  def number_field
+    project.provider.in?(%w(github gitlab)) ? "#{ project.provider }_issue_number" : 'bitbucket_issue_id'
+  end
+end

--- a/app/models/pull_request_subtask.rb
+++ b/app/models/pull_request_subtask.rb
@@ -1,0 +1,5 @@
+class PullRequestSubtask < ActiveRecord::Base
+  belongs_to :pull_request
+
+  validates :description, :length => { :maximum => Settings.max_text_field_size }, :presence => true
+end

--- a/app/models/pull_request_to_issue_connection.rb
+++ b/app/models/pull_request_to_issue_connection.rb
@@ -1,0 +1,5 @@
+class PullRequestToIssueConnection < ActiveRecord::Base
+  belongs_to :pull_request
+
+  belongs_to :issue
+end

--- a/app/services/generate_changelogs.rb
+++ b/app/services/generate_changelogs.rb
@@ -1,0 +1,272 @@
+class GenerateChangelogs
+  def initialize(params = {})
+    @project = params[:project]
+
+    @provider = @project.provider
+
+    @client = @project.send("#{ @provider }_client_for_changelogs")
+
+    I18n.locale = @project.changelog_locale
+  end
+
+  Settings.issues_providers.each do |provider|
+    define_method "#{ provider }_tag_name_and_last_commit_sha" do |tag|
+      {
+        :tag_name => send("#{ provider }_tag_name", tag),
+        :last_commit_sha => send("#{ provider }_last_commit_sha", tag)
+      }
+    end
+  end
+
+  def handle_changelogs
+    return unless @client.present?
+
+    generate_changelogs
+
+    generate_pull_requests
+
+    changelogs = @project.changelogs.where(:handled => false)
+
+    process_not_handled_changelogs(changelogs)
+
+    changelogs.update_all(:handled => true)
+  end
+
+  def generate_changelogs
+    send("tags_from_#{ @provider }").each { |tag| create_or_fetch_changelog(fetch_tag_info(tag)) }
+  end
+
+  def tags_from_github
+    @client.tags(@project.github_full_name)
+  end
+
+  def tags_from_gitlab
+    @client.tags(@project.gitlab_repository_id)
+  end
+
+  def tags_from_bitbucket
+    @client.repos.tags(@project.bitbucket_owner, @project.bitbucket_slug)
+  end
+
+  def create_or_fetch_changelog(tag_info)
+    @project.changelogs.where(tag_info).first_or_create!
+  end
+
+  def fetch_tag_info(tag)
+    {
+      :tag_name => send("#{ @provider }_tag_name", tag),
+      :last_commit_sha => send("#{ @provider }_last_commit_sha", tag),
+      :last_commit_date => send("fetch_#{ @provider }_last_commit_date", tag)
+    }
+  end
+
+  def github_tag_name(tag)
+    tag[:name]
+  end
+
+  def github_last_commit_sha(tag)
+    tag[:commit][:sha]
+  end
+
+  def fetch_github_last_commit_date(tag)
+    changelog = @project.changelogs.find_by(github_tag_name_and_last_commit_sha(tag))
+
+    return changelog.last_commit_date if changelog.present?
+
+    @client.commit(@project.github_repository_id, tag[:commit][:sha]).commit.author.date
+  end
+
+  def gitlab_tag_name(tag)
+    tag.name
+  end
+
+  def gitlab_last_commit_sha(tag)
+    tag.commit.id
+  end
+
+  def fetch_gitlab_last_commit_date(tag)
+    DateTime.parse(tag.commit.committed_date).utc
+  end
+
+  def bitbucket_tag_name(tag)
+    tag.first
+  end
+
+  def bitbucket_last_commit_sha(tag)
+    tag.last['raw_node']
+  end
+
+  def fetch_bitbucket_last_commit_date(tag)
+    DateTime.parse(tag.last['utctimestamp']).utc
+  end
+
+  def create_or_fetch_pull_request(pull_request_info)
+    pull_request = @project.pull_requests.where(:id_from_provider => pull_request_info[:id_from_provider]).
+      first_or_initialize
+
+    changelog = @project.changelogs.where('last_commit_date >=?', pull_request_info[:merged_at]).
+      order('last_commit_date ASC').first
+
+    return if return_pull_request?(pull_request)
+
+    handle_pull_request(pull_request, changelog, pull_request_info)
+  end
+
+  def handle_pull_request(pull_request, changelog, pull_request_info)
+    pull_request.assign_attributes({ :changelog => changelog, :project => @project }.merge(pull_request_info))
+
+    pull_request.save!
+  end
+
+  def generate_pull_requests
+    send("#{ @provider }_fetch_pull_requests").each do |pull_request|
+      create_or_fetch_pull_request(fetch_pull_request_info(pull_request))
+    end
+  end
+
+  def fetch_pull_request_info(pull_request)
+    {
+      :id_from_provider => send("#{ @provider }_id_from_provider", pull_request),
+      :title => send("#{ @provider }_pull_request_title", pull_request),
+      :body => send("#{ @provider }_pull_request_body", pull_request),
+      :merged_at => send("#{ @provider }_pull_request_merged_at", pull_request),
+      :created_by => send("#{ @provider }_pull_request_created_by", pull_request),
+      :author_url => send("#{ @provider }_pull_request_author_url", pull_request),
+      "#{ @provider }_url" => send("#{ @provider }_pull_request_url", pull_request),
+      :number_from_provider => send("#{ @provider }_pull_request_number", pull_request)
+    }
+  end
+
+  def github_id_from_provider(pull_request)
+    pull_request['id']
+  end
+
+  def github_pull_request_title(pull_request)
+    pull_request['title']
+  end
+
+  def github_pull_request_body(pull_request)
+    pull_request['body']
+  end
+
+  def github_pull_request_merged_at(pull_request)
+    pull_request['merged_at']
+  end
+
+  def github_pull_request_created_by(pull_request)
+    pull_request['user']['login']
+  end
+
+  def github_pull_request_author_url(pull_request)
+    pull_request['user']['html_url']
+  end
+
+  def github_pull_request_url(pull_request)
+    pull_request['html_url']
+  end
+
+  def github_pull_request_number(pull_request)
+    pull_request['number']
+  end
+
+  def gitlab_id_from_provider(pull_request)
+    pull_request.id
+  end
+
+  def gitlab_pull_request_title(pull_request)
+    pull_request.title
+  end
+
+  def gitlab_pull_request_body(pull_request)
+    pull_request.description
+  end
+
+  def gitlab_pull_request_merged_at(pull_request)
+    # We don't know about when merge request was merged from gitlab,
+    # we can only get merge request updated at(https://github.com/gitlabhq/gitlabhq/blob/dad406da23f7a4d94f9f8df1a4b8743dc0e9dc96/lib/gitlab/github_import/pull_request_formatter.rb#L95)
+    # and consider it as merged at date.
+    # But often it is about 5 seconds later than it was realy merged.
+    # If you know how to improve that method, please contact me or send PR.
+    DateTime.parse(pull_request.updated_at).utc - 5.seconds
+  end
+
+  def gitlab_pull_request_created_by(pull_request)
+    pull_request.author.username
+  end
+
+  def gitlab_pull_request_author_url(pull_request)
+    pull_request.author.web_url
+  end
+
+  def gitlab_pull_request_url(pull_request)
+    "#{ Settings.gitlab_base_url }/#{ @project.gitlab_full_name }/merge_requests/#{ pull_request.iid }"
+  end
+
+  def gitlab_pull_request_number(pull_request)
+    pull_request.iid
+  end
+
+  def bitbucket_id_from_provider(pull_request)
+    pull_request.id
+  end
+
+  def bitbucket_pull_request_title(pull_request)
+    pull_request.title
+  end
+
+  def bitbucket_pull_request_body(pull_request)
+    pull_request.description
+  end
+
+  def bitbucket_pull_request_merged_at(pull_request)
+    DateTime.parse(@client.repos.commit.list(@project.bitbucket_owner,
+      @project.bitbucket_slug, pull_request['merge_commit']['hash'])['date']).utc
+  end
+
+  def bitbucket_pull_request_created_by(pull_request)
+    pull_request.author.username
+  end
+
+  def bitbucket_pull_request_author_url(pull_request)
+    pull_request.author['links']['html']['href']
+  end
+
+  def bitbucket_pull_request_url(pull_request)
+    pull_request['links']['html']['href']
+  end
+
+  def bitbucket_pull_request_number(pull_request)
+    pull_request.id
+  end
+
+  def github_fetch_pull_requests
+    @client.pull_requests(@project.github_full_name, :state => 'closed')
+  end
+
+  def gitlab_fetch_pull_requests
+    @client.merge_requests(@project.gitlab_repository_id, :state => 'merged')
+  end
+
+  def bitbucket_fetch_pull_requests
+    @client.repos.pull_request.
+      list(@project.bitbucket_owner, @project.bitbucket_slug, :state => 'merged')['values']
+  end
+
+  def process_not_handled_changelogs(changelogs)
+    return unless changelogs.any?
+
+    ProjectMailer.changelogs_email(changelogs.map(&:id)).deliver_later if @project.emails_for_reports.any?
+
+    changelogs.each(&:close_issues) if @project.close_issues?
+
+    @project.write_changelog if @project.write_changelog_to_repository?
+  end
+
+  private
+
+  # There are some problems to define merged at date for gitlab pull request.
+  # We define it as updated at field from api for gitlab, so we suppose it won't change in the future.
+  def return_pull_request?(pull_request)
+    pull_request.persisted? && pull_request.provider == 'gitlab' && pull_request.changelog_id.present?
+  end
+end

--- a/app/views/changelogs/_changelog.html.slim
+++ b/app/views/changelogs/_changelog.html.slim
@@ -1,0 +1,38 @@
+h2 = "#{ changelog.tag_name } (#{ changelog.last_commit_date.strftime('%d.%m.%Y %H:%M') })"
+
+- if changelog.project.include_pull_requests?
+  h3 = t '.changes'
+
+  ul
+    - changelog.pull_requests.order('merged_at DESC').each do |pull_request|
+      li
+        = pull_request.title
+        | &nbsp;(
+        = link_to "##{ pull_request.number_from_provider }", pull_request.url_from_provider
+        | &nbsp;
+        = t '.by'
+        | &nbsp;
+        = link_to "@#{ pull_request.created_by }", pull_request.author_url
+        | )
+
+- if changelog.project.include_detailed_changes?
+  h3 = t '.detailed_changes'
+
+  ol
+    - changelog.pull_request_subtasks.sort_by { |item| Settings.story_point_values.index(item) }.\
+      each_with_index do |subtask, index|
+      
+      li = "#{ "[#{ subtask.task_type }]" if subtask.task_type.present? }" +\
+        "#{ "[#{ subtask.story_points }]" if subtask.story_points.present? }" +\
+        " #{ subtask.description } \n"
+
+- if changelog.project.include_issues?
+  h3 = t '.issues'
+
+  ul
+    - changelog.pull_requests.map(&:issues).flatten.each do |issue|
+      li
+        = issue.title
+        | &nbsp;(
+        = link_to "##{ issue.send("#{ issue.provider }_issue_number") }", issue.url_from_provider
+        | )

--- a/app/views/changelogs/_changelog_list_item.html.slim
+++ b/app/views/changelogs/_changelog_list_item.html.slim
@@ -1,0 +1,16 @@
+li.list-group-item
+  = changelog.tag_name
+
+  .pull-right
+    = link_to (t '.resend'), resend_project_changelog_url(changelog.project, changelog),
+      :class => 'btn btn-success btn-xs'
+
+    | &nbsp;
+    
+    = link_to (t '.view_as_html'), project_changelog_url(changelog.project, changelog),
+      :class => 'btn btn-default btn-xs'
+
+    | &nbsp;
+
+    = link_to (t '.view_as_raw_md'), project_changelog_url(changelog.project, changelog, :format => :text),
+      :class => 'btn btn-default btn-xs'

--- a/app/views/changelogs/_changelog_raw_md.html.slim
+++ b/app/views/changelogs/_changelog_raw_md.html.slim
@@ -1,0 +1,26 @@
+= "## #{ changelog.tag_name } (#{ changelog.last_commit_date.strftime('%d.%m.%Y %H:%M') }) \n"
+
+- if changelog.project.include_pull_requests?
+  = "\n### #{ t '.changes' } \n"
+
+  - changelog.pull_requests.order('merged_at DESC').each do |pull_request|
+    = "* #{ pull_request.title } " +\
+      "([##{ pull_request.number_from_provider }](#{ pull_request.url_from_provider }) " +\
+      "#{ t '.by' } [@#{ pull_request.created_by }](#{ pull_request.author_url })) \n"
+
+- if changelog.project.include_detailed_changes?
+  = "\n### #{ t '.detailed_changes' } \n"
+
+  - changelog.pull_request_subtasks.sort_by { |item| Settings.story_point_values.index(item) }.\
+    each_with_index do |subtask, index|
+    = "#{ index }. " + "#{ "[#{ subtask.task_type }]" if subtask.task_type.present? }" +\
+      "#{ "[#{ subtask.story_points }]" if subtask.story_points.present? }" +\
+      " #{ subtask.description } \n"
+
+- if changelog.project.include_issues?
+  = "\n### #{ t '.issues' } \n"
+
+  - changelog.pull_requests.map(&:issues).flatten.each do |issue|
+    = "* #{ issue.title } ([##{ issue.send("#{ issue.provider }_issue_number") }]" +\
+      "(#{ issue.url_from_provider }))\n"
+= "\n"

--- a/app/views/changelogs/index.html.slim
+++ b/app/views/changelogs/index.html.slim
@@ -1,0 +1,16 @@
+h3
+  = t '.project'
+
+  | &nbsp;
+
+  = @project.name
+
+ul.list-group
+  li.list-group-item.list-group-item-info
+    = (t '.changelogs').capitalize
+    .pull-right
+      = link_to (t '.sync'), sync_project_changelogs_url(@project), :class => 'btn btn-success btn-xs'
+
+  = render :partial => 'changelogs/changelog_list_item', :collection => @changelogs, :as => :changelog
+
+= paginate @changelogs

--- a/app/views/changelogs/show.html.slim
+++ b/app/views/changelogs/show.html.slim
@@ -1,0 +1,1 @@
+= render @changelog

--- a/app/views/issue_to_section_connections/_issue_to_section_connection.html.slim
+++ b/app/views/issue_to_section_connections/_issue_to_section_connection.html.slim
@@ -20,7 +20,7 @@ div [data-issue_to_section_connection-id = "#{ issue_to_section_connection.id }"
         i.fa.fa-pencil.fa-lg
   p
     - if issue.github_issue_html_url.present?
-      = link_to issue.github_issue_html_url do
+      = link_to issue.url_from_provider do
         i.fa.fa-github
     - if issue.github_issue_comments_count.present?
       | &nbsp;
@@ -30,8 +30,7 @@ div [data-issue_to_section_connection-id = "#{ issue_to_section_connection.id }"
 
     - if issue.bitbucket_issue_id.present?
       | &nbsp;
-      = link_to "#{ Settings.bitbucket_base_url }/" +\
-        "#{ issue.project.bitbucket_full_name }/issues/#{ issue.bitbucket_issue_id }" do
+      = link_to issue.url_from_provider do
         i.fa.fa-bitbucket
 
     - if issue.bitbucket_issue_comment_count.present?
@@ -42,8 +41,7 @@ div [data-issue_to_section_connection-id = "#{ issue_to_section_connection.id }"
 
     - if issue.gitlab_issue_id.present?
       | &nbsp;
-      = link_to "#{ Settings.gitlab_base_url }/" +\
-        "#{ issue.project.gitlab_full_name }/issues/#{ issue.gitlab_issue_id }" do
+      = link_to issue.url_from_provider do
         i.fa.fa-gitlab
 
   - if issue.tags.present?

--- a/app/views/layouts/mailer.html.slim
+++ b/app/views/layouts/mailer.html.slim
@@ -1,0 +1,3 @@
+html
+  body
+    = yield

--- a/app/views/project_mailer/changelogs_email.html.slim
+++ b/app/views/project_mailer/changelogs_email.html.slim
@@ -1,0 +1,4 @@
+h1 = @subject 
+
+- @changelogs.each do |changelog|
+  = render changelog

--- a/app/views/projects/_form.html.slim
+++ b/app/views/projects/_form.html.slim
@@ -11,6 +11,70 @@
 
   hr
 
+  h3
+    = t '.changelogs'
+    br
+    small = t '.changelogs_info'
+  
+
+  .checkbox
+    label
+      = form.check_box :generate_changelogs
+
+      = t '.generate_changelogs'
+
+  .checkbox
+    label
+      = form.check_box :include_issues
+      
+      = t '.include_issues'
+
+  .checkbox
+    label
+      = form.check_box :include_detailed_changes
+      
+      = t '.include_detailed_changes'
+
+  .checkbox
+    label
+      = form.check_box :include_pull_requests
+      
+      = t '.include_pull_requests'
+
+  .checkbox
+    label
+      = form.check_box :close_issues
+      
+      = t '.close_issues'
+
+  .checkbox
+    label
+      = form.check_box :write_changelog_to_repository
+      
+      = t '.write_to_changelog_file'
+
+  .form-group
+    label for = 'changelog_filename' = t '.changelog_filename'
+
+    = form.text_field :changelog_filename, :class => 'form-control',
+      :placeholder => (t '.enter_changelog_filename')
+
+  .form-group
+    label for = 'changelog_locale' = t '.changelog_locale'
+
+    = form.select :changelog_locale, language_options_for_settings_select, {},
+      { :class => 'form-control', :id => 'locale' }
+
+  .form-group
+    label for = 'emails_for_reports' = t '.emails_for_reports'
+
+    = form.select :emails_for_reports,
+      options_for_select(form.object.emails_for_reports.tap { |t| t.delete('') },
+      :selected => form.object.emails_for_reports.tap { |t| t.delete('') }), { },
+      :multiple => true, :class => 'form-control emails_for_reports'
+
+  hr
+
   - if project.is_github_repository
     h3 = t 'github'
     
@@ -48,7 +112,7 @@
 
     input.form-control disabled = '' placeholder=("#{ project.gitlab_full_name }") type = 'text'
 
-    label = t '.bitbucket_secret_token_for_hook'
+    label = t '.gitlab_secret_token_for_hook'
 
     input.form-control disabled = '' placeholder=("#{ project.gitlab_secret_token_for_hook }") type = 'text'
 

--- a/app/views/projects/_project.html.slim
+++ b/app/views/projects/_project.html.slim
@@ -22,7 +22,11 @@ li.list-group-item
       i.fa.fa-gitlab
 
   .pull-right
-    = link_to (t '.project_issues'), project_issues_url(project), :class => 'btn btn-default btn-xs'
+    = link_to (t '.changelogs'), project_changelogs_url(project), :class => 'btn btn-default btn-xs'
+
+    | &nbsp;
+    
+    = link_to (t '.issues'), project_issues_url(project), :class => 'btn btn-default btn-xs'
     
     | &nbsp;
 
@@ -32,4 +36,4 @@ li.list-group-item
 
     = link_to (t '.destroy'), user_project_url(current_user, project),
       :class => 'btn btn-default btn-xs btn-danger',
-      :method => 'delete', :data => { :confirm => 'Вы уверены?' }
+      :method => 'delete', :data => { :confirm => (t '.are_you_sure') }

--- a/app/views/projects/edit.js.erb
+++ b/app/views/projects/edit.js.erb
@@ -1,0 +1,7 @@
+$('#project_form').replaceWith('<%= j render 'form', :project => @project, :remote => true %>');
+
+if (($('#project_modal').data('bs.modal') || { isShown: false }).isShown == false) {
+  $('#project_modal').modal('show');
+}
+
+window.init_tags();

--- a/app/views/projects/new.js.erb
+++ b/app/views/projects/new.js.erb
@@ -3,3 +3,5 @@ $('#project_modal #project_form').replaceWith('<%= j render 'form', :project => 
 if (($('#project_modal').data('bs.modal') || { isShown: false }).isShown == false) {
   $('#project_modal').modal('show');
 }
+
+window.init_tags();

--- a/app/views/projects/show.html.slim
+++ b/app/views/projects/show.html.slim
@@ -3,11 +3,124 @@ h1
   | &nbsp;
   = @project.name
 
-h3 = t '.project_info'
-
 p = link_to "#{ t '.project_issues' } (#{ @project.open_issues })", project_issues_url(@project)
 
 p = link_to "#{ t '.project_users' } (#{ @project.users.size })", project_users_url(@project)
+
+hr
+
+h4 = t '.changelogs'
+p
+  b
+    = t '.generate_changelogs'
+    | :&nbsp;
+  = @project.generate_changelogs
+p
+  b
+    = t '.include_issues'
+    | :&nbsp;
+  = @project.include_issues
+
+p
+  b
+    = t '.include_detailed_changes'
+    | :&nbsp;
+  = @project.include_detailed_changes
+
+p
+  b
+    = t '.include_pull_requests'
+    | :&nbsp;
+  = @project.include_pull_requests
+
+p
+  b
+    = t '.close_issues'
+    | :&nbsp;
+  = @project.close_issues
+
+p
+  b
+    = t '.write_to_changelog_file'
+    | :&nbsp;
+  = @project.write_changelog_to_repository
+
+p
+  b
+    = t '.changelog_filename'
+    | :&nbsp;
+  = @project.changelog_filename
+
+p
+  b
+    = t '.changelog_locale'
+    | :&nbsp;
+  = @project.changelog_locale
+
+p
+  b
+    = t '.emails_for_reports'
+    | :&nbsp;
+  = @project.emails_for_reports.join(',')
+hr
+
+- if @project.is_github_repository
+  h4 = t 'github'
+  
+  p
+    b
+      = t '.github_repository_id'
+      | :&nbsp;
+    = @project.github_repository_id
+
+  p
+    b
+      = t '.github_full_name'
+      | :&nbsp;
+
+    = @project.github_full_name
+
+  p
+    b = t '.github_secret_token_for_hook'
+    | :&nbsp;
+
+    = @project.github_secret_token_for_hook
+  
+- if @project.is_bitbucket_repository
+  h4 = t 'bitbucket'
+  
+  p
+    b
+      = t '.bitbucket_full_name'
+      | :&nbsp;
+
+    = @project.bitbucket_full_name
+
+  p
+    b
+      = t '.bitbucket_secret_token_for_hook'
+      | :&nbsp;
+
+    = @project.bitbucket_secret_token_for_hook
+
+- if @project.is_gitlab_repository
+  h4 = t 'gitlab'
+  
+  p
+    b
+      = t '.gitlab_full_name'
+      | :&nbsp;
+
+    = @project.gitlab_full_name
+
+  p
+    b
+      = t '.bitbucket_secret_token_for_hook'
+      | :&nbsp
+
+    = @project.gitlab_secret_token_for_hook
+
+hr
 
 ul.list-group
   li.list-group-item.list-group-item-info
@@ -20,3 +133,10 @@ ul.list-group
   = render @boards
 
 = paginate @boards
+
+= link_to (t '.edit'), edit_user_project_url(current_user, @project), :class => 'btn btn-default'
+
+| &nbsp;
+
+= link_to (t '.destroy'), user_project_url(current_user, @project), :class => 'btn btn-default btn-danger',
+  :method => 'delete', :data => { :confirm => (t '.are_you_sure') }

--- a/app/views/projects/update.js.erb
+++ b/app/views/projects/update.js.erb
@@ -1,1 +1,0 @@
-console.log('yay');

--- a/app/views/shared/_form_errors.html.slim
+++ b/app/views/shared/_form_errors.html.slim
@@ -4,5 +4,5 @@
     = t ".#{ error_key.to_s.singularize }"
 
     | &nbsp;:&nbsp;
-    
+
     = error_value

--- a/app/views/shared/_header.html.slim
+++ b/app/views/shared/_header.html.slim
@@ -1,7 +1,7 @@
-.navbar.navbar-inverse.navbar-static-top.navbar_customized role='navigation' 
+.navbar.navbar-inverse.navbar-static-top.navbar_customized role='navigation'
   .container-fluid
     .navbar-header
-      button.navbar-toggle data-target=".navbar-collapse" data-toggle="collapse" type="button" 
+      button.navbar-toggle data-target=".navbar-collapse" data-toggle="collapse" type="button"
         span.icon-bar
         span.icon-bar
         span.icon-bar

--- a/app/views/shared/_javascript_global_variables.html.erb
+++ b/app/views/shared/_javascript_global_variables.html.erb
@@ -7,5 +7,7 @@
   
   window.i18n_issue_tags = "<%= t '.select_issue_tags' %>";
 
+  window.i18n_emails_for_reports = "<%= t '.emails_for_reports' %>";
+
   window.current_path = "<%= request.path %>"
 <% end %>

--- a/app/views/shared/_languages_select_modal.html.slim
+++ b/app/views/shared/_languages_select_modal.html.slim
@@ -1,6 +1,6 @@
 #language_modal.modal.fade [ aria-hidden = 'true'
-  aria-labelledby = 'available_languages' role = 'dialog' tabindex = '-1'] 
-  
+  aria-labelledby = 'available_languages' role = 'dialog' tabindex = '-1']
+
   .modal-dialog role = 'document'
     .modal-content
       .modal-header

--- a/app/views/shared/_left_sidebar.html.slim
+++ b/app/views/shared/_left_sidebar.html.slim
@@ -1,8 +1,8 @@
 - if user_signed_in?
   .list-group.hidden-xs
-    .list-group-item.list-group-item-info 
+    .list-group-item.list-group-item-info
       = t '.boards'
     - current_user.boards.order('created_at DESC').limit(5).each do |board|
       = link_to board_url(board), :class => 'list-group-item truncate' do
-        = board.name 
+        = board.name
         .badge = board.issues.size

--- a/app/views/shared/_navbar.html.slim
+++ b/app/views/shared/_navbar.html.slim
@@ -8,7 +8,7 @@
         = (t '.syncing_with_github')
         | &nbsp;
         i.fa.fa-refresh.fa-spin.fa-fw
-    
+
     - if current_user.has_bitbucket_account && current_user.sync_with_bitbucket
       = link_to user_projects_url(current_user),
         :class => 'btn btn-default navbar-btn', :id => 'navbar_bitbucket_sync_info' do
@@ -25,6 +25,11 @@
 
     = link_to new_user_project_url(current_user), :remote => true, :class => 'btn btn-success navbar-btn' do
       i.fa.fa-plus
+
+    - if params[:controller] == 'projects' && params[:action] == 'show'
+      = link_to edit_user_project_url(current_user, @project), :remote => true,
+        :class => 'btn btn-success navbar-btn' do
+        i.fa.fa-pencil
 
   | &nbsp;
   .btn-group

--- a/app/workers/generate_changelog_worker.rb
+++ b/app/workers/generate_changelog_worker.rb
@@ -1,0 +1,13 @@
+class GenerateChangelogWorker
+  include Sidekiq::Worker
+
+  def perform(project_id)
+    project = Project.where(:id => project_id).first
+
+    return unless project.present?
+
+    if Settings.issues_providers.map { |provider| project.send("is_#{ provider }_repository") }.any?
+      GenerateChangelogs.new(:project => project).handle_changelogs
+    end
+  end
+end

--- a/app/workers/notification_worker.rb
+++ b/app/workers/notification_worker.rb
@@ -1,5 +1,6 @@
 class NotificationWorker
   include Sidekiq::Worker
+  include Viewable
 
   def perform(issue_id, user_id)
     @user = User.find(user_id)
@@ -13,17 +14,6 @@ class NotificationWorker
   end
 
   private
-
-  def view
-    ActionView::Base.new(Rails.configuration.paths['app/views']).tap do |av|
-      av.class_eval do
-        include Rails.application.routes.url_helpers
-        include ApplicationHelper
-        include Devise::Controllers::Helpers
-        include CanCan::ControllerAdditions
-      end
-    end
-  end
 
   %w(body title title_with_body_html).each do |part|
     define_method "render_#{ part }" do

--- a/config/application.rb
+++ b/config/application.rb
@@ -35,5 +35,7 @@ module KanbanOnRails
     config.middleware.delete 'Rack::Lock'
 
     config.active_job.queue_adapter = :sidekiq
+
+    config.autoload_paths << Rails.root.join('lib')
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -81,6 +81,10 @@ en: &all
   1_we_have_just_launched_our_service_title: We have just launched our service
   open: Open
   closed: Closed
+  releases: releases
+  release: release
+  changelog_has_been_resent: Changelog has been resent
+  changelogs_has_been_synced: Changelog has been synced
   shared:
     navbar:
       sign_in: Sign in
@@ -126,6 +130,7 @@ en: &all
       select_column_tags: Select column tags
       select_section_tags: Select section tags
       select_issue_tags: Select issue tags
+      emails_for_reports: Type emails which will recieve changelogs
     email_signature:
       info: Info
       mailer: Mailer
@@ -217,11 +222,27 @@ en: &all
       github_secret_token_for_hook: Github secret token for hook
       bitbucket_full_name: Bitbucket fullname
       bitbucket_secret_token_for_hook: Bitbucket secret token for hook
+      gitlab_full_name: Gitlab fullname
+      github_secret_token_for_hook: Gitlab secret token for hook
+      changelogs: Changelogs
+      changelogs_info: if you want to keep changelogs
+      generate_changelogs: Generate changelogs
+      include_detailed_changes: Include detailed changes described in pull requests
+      include_issues: Include issues in changelogs
+      include_pull_requests: Include pull requests in changelogs
+      close_issues: Close done issues
+      emails_for_reports: Emails for recieving changelogs
+      write_to_changelog_file: Write changelogs to the repository file
+      changelog_filename: Changelog filename
+      enter_changelog_filename: Enter changelog filename(default "CHANGELOG")
+      changelog_locale: Choose language for changelogs
     project:
       edit: Edit
       destroy: Delete
-      project_issues: Project issues
-      project_users: Project users
+      issues: Issues
+      users: Users
+      changelogs: Changelogs
+      are_you_sure: Are you sure?
     section_fields:
       section_name: Section name
       remove_section: Remove section
@@ -241,6 +262,26 @@ en: &all
       project_issues: Project issues
       project_users: Project users
       new: New
+      edit: Edit
+      destroy: Delete
+      are_you_sure: Are you sure?
+      changelogs: Changelogs
+      github_repository_id: Github repository id
+      github_full_name: Github repository fullname
+      github_secret_token_for_hook: Github secret token for hook
+      bitbucket_full_name: Bitbucket fullname
+      bitbucket_secret_token_for_hook: Bitbucket secret token for hook
+      gitlab_full_name: Gitlab fullname
+      github_secret_token_for_hook: Gitlab secret token for hook
+      generate_changelogs: Generate changelogs
+      include_detailed_changes: Include detailed changes described in pull requests
+      include_issues: Include issues in changelogs
+      include_pull_requests: Include pull requests in changelogs
+      close_issues: Close done issues
+      emails_for_reports: Emails for recieving changelogs
+      write_to_changelog_file: Write changelogs to the repository file
+      changelog_filename: Changelog filename
+      changelog_locale: Language for changelog
     project_modal:
       project: Project
   issues:
@@ -349,6 +390,25 @@ en: &all
       close: Close
       cancel: Cancel
       more: Send more
+  changelogs:
+    changelog_raw_md:
+      changes: Changes
+      detailed_changes: Detailed changes
+      issues: Issues
+      by: by
+    changelog:
+      changes: Changes
+      detailed_changes: Detailed changes
+      issues: Issues
+      by: by
+    index:
+      project: Project
+      changelogs: Changelogs
+      sync: Sync
+    changelog_list_item:
+      resend: Resend
+      view_as_html: View as html
+      view_as_raw_md: View as raw md
   pages:
     faq:
       faq: FAQ

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -8,6 +8,10 @@ ru:
   backlog: Бэклог
   open: Открыта
   closed: Закрыта
+  releases: релизы
+  release: релиз
+  changelog_has_been_resent: Изменения(changelog) были переотправлены
+  changelogs_has_been_synced: Изменения(changelog) были синхронизированы
   shared:
     navbar:
       sign_in: Вход
@@ -51,6 +55,7 @@ ru:
       select_column_tags: Выберите теги столбцов
       select_section_tags: Выберите теги раздела
       select_issue_tags: Выберите теги задачи
+      emails_for_reports: Введите емейлы, на которые будут приходить отчёты
     pagination_link:
       next_page: Следующая страница
     sync_with_provider_button:
@@ -134,14 +139,30 @@ ru:
       column_height: Высота столбца
       github_repository_id: Github Id репозитория
       github_full_name: Полное название репозитория на Github
-      github_secret_token_for_hook: Github секретный token для создания хука
+      github_secret_token_for_hook: Github секретный токен для создания хука
       bitbucket_full_name: BitBucket полное название
-      bitbucket_secret_token_for_hook: BitBucket секретный token для хука
+      bitbucket_secret_token_for_hook: BitBucket секретный токен для хука
+      gitlab_full_name: Название проекта в Gitlab
+      gitlab_secret_token_for_hook: Gitlab секретный токен для хука
+      changelogs: Журнал изменений проекта(Changelogs)
+      changelogs_info: Заполните, если хотите вести журнал изменений
+      generate_changelogs: Генерировать отчёты(changelogs)
+      include_detailed_changes: Включить в отчёты детальные изменения описанные в Pull Requests
+      include_issues: Включать в отчёты сделанные задачи(issues)
+      include_pull_requests: Включить в отчёты Pull Request'ы
+      close_issues: Закрывать тикеты при деплое и генерации отчёта
+      emails_for_reports: Емейлы, на которые будут отправляться отчёты
+      write_to_changelog_file: Записывать изменения в файл репозитории проекта
+      changelog_filename: Название файла в репозитории, куда будут записываться изменения
+      enter_changelog_filename: Введите название файла для изменений(по-умолчанию CHANGELOG)
+      changelog_locale: Выберите язык, на котором будут писаться отчёты(Changelog'и)
     project:
       edit: Редактировать
       destroy: Удалить
-      project_issues: Задачи проекта
-      project_users: Пользователи проекта
+      issues: Задачи
+      changelogs: Изменения(changelog'и)
+      users: Пользователи
+      are_you_sure: Вы уверены?
     section_fields:
       section_name: Название секции
       remove_section: Удалить раздел
@@ -161,6 +182,25 @@ ru:
       project_issues: Задачи проекта
       project_users: Участники проекта
       new: Новая
+      edit: Редактировать
+      destroy: Удалить
+      are_you_sure: Вы уверены?
+      github_repository_id: Github Id репозитория
+      github_full_name: Полное название репозитория на Github
+      github_secret_token_for_hook: Github секретный токен для создания хука
+      bitbucket_full_name: BitBucket полное название
+      bitbucket_secret_token_for_hook: BitBucket секретный токен для хука
+      gitlab_full_name: Gitlab полное название проекта
+      github_secret_token_for_hook: Gitlab секретный токен для хука
+      generate_changelogs: Генерировать отчёты(changelogs)
+      include_detailed_changes: Включить в отчёты детальные изменения описанные в Pull Requests
+      include_issues: Включать в отчёты сделанные задачи(issues)
+      include_pull_requests: Включить в отчёты Pull Request'ы
+      close_issues: Закрывать тикеты при деплое и генерации отчёта
+      emails_for_reports: Емейлы, на которые будут отправляться отчёты
+      write_to_changelog_file: Записывать изменения в файл репозитории проекта
+      changelog_filename: Название файла в репозитории, куда будут записываться изменения
+      changelog_locale: Язык, который используется для генерации отчётов
     project_modal:
       project: Проект
   issues:
@@ -274,6 +314,25 @@ ru:
       close: Закрыть
       cancel: Отмена
       more: Отправить ещё
+  changelogs:
+    changelog_raw_md:
+      changes: Изменения
+      detailed_changes: Подробные изменения
+      issues: Задачи
+      by: сделан пользователем
+    changelog:
+      changes: Изменения
+      detailed_changes: Подробные изменения
+      issues: Задачи
+      by: сделан пользователем
+    index:
+      project: Проект
+      changelogs: Изменения(changelog'и)
+      sync: Синхронизировать
+    changelog_list_item:
+      resend: Переотправить
+      view_as_html: Посмотреть html
+      view_as_raw_md: Посмотреть md
   pages:
     faq:
       faq: Часто задаваемые вопросы

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,8 +12,6 @@ Rails.application.routes.draw do
   }
 
   devise_scope :user do
-    post 'omniauth_finish' => 'omniauth_callbacks#omniauth_finish'
-
     resource :registration,
       :only => [:new, :create],
       :path => 'users',
@@ -45,6 +43,12 @@ Rails.application.routes.draw do
     resources :issues
 
     resources :users, :only => [:index]
+
+    resources :changelogs, :only => [:index, :show] do
+      get :resend, :on => :member
+
+      get :sync, :on => :collection
+    end
 
     post :payload_from_github, :payload_from_bitbucket, :payload_from_gitlab, :on => :member
   end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -8,12 +8,19 @@ mailer:
 max_string_field_size: 255
 max_text_field_size: 65536
 max_column_width: 10000
+max_column_height: 100000
 production_server_deploy_host: kanbanonrails.com
 git_repository: git@github.com:technoeleganceteam/kanban_on_rails.git
 github_repository_url: https://github.com/technoeleganceteam/kanban_on_rails
 bitbucket_base_url: https://bitbucket.com
 gitlab_base_url: https://gitlab.com
 gitlab_endpoint: https://gitlab.com/api/v3
+issue_binding_words:
+  - connects to
+  - connects with
+  - connect to
+  - connect with
+  - fix
 issue_states:
   - open
   - closed
@@ -25,6 +32,12 @@ postgresql:
   test_database_name: travis_ci_test
   username: postgres
   password:
+story_point_values:
+  - XS
+  - S
+  - M
+  - L
+  - XL
 secret_key_base: 66dfbcd8b3a121137d2195ae39f7d63b0e1eb9e05018b73e5e8dee29576f2f1cf2ab8c008d002547e8976eb9efd1a023054f63aa6d6247e3ec3bb49cac8b5631
 secret_token: 66dfbcd8b3a121137d2195ae39f7d63b0e1eb9e05018b73e5e8dee29576f2f1cf2ab8c008d002547e8976eb9efd1a023054f63aa6d6247e3ec3bb49cac8b5631
 webhook_host:  http://66432e6d.ngrok.io

--- a/db/migrate/20160630163256_create_changelogs.rb
+++ b/db/migrate/20160630163256_create_changelogs.rb
@@ -1,0 +1,19 @@
+class CreateChangelogs < ActiveRecord::Migration
+  def change
+    create_table :changelogs do |t|
+      t.belongs_to :project, :index => true
+
+      t.string :tag_name, :null => false
+
+      t.string :last_commit_sha, :null => false
+
+      t.datetime :last_commit_date, :null => false
+
+      t.boolean :handled, :null => false, :default => false
+
+      t.jsonb :meta, :default => {}
+
+      t.timestamps :null => false
+    end
+  end
+end

--- a/db/migrate/20160701214133_create_pull_requests.rb
+++ b/db/migrate/20160701214133_create_pull_requests.rb
@@ -1,0 +1,23 @@
+class CreatePullRequests < ActiveRecord::Migration
+  def change
+    create_table :pull_requests do |t|
+      t.belongs_to :project, :index => true
+
+      t.belongs_to :changelog, :index => true
+
+      t.string :title, :null => false
+
+      t.datetime :merged_at, :null => false
+
+      t.text :body
+
+      t.string :id_from_provider, :null => false
+
+      t.string :created_by
+
+      t.jsonb :meta, :default => {}
+
+      t.timestamps :null => false
+    end
+  end
+end

--- a/db/migrate/20160701230737_create_pull_request_to_issue_connections.rb
+++ b/db/migrate/20160701230737_create_pull_request_to_issue_connections.rb
@@ -1,0 +1,11 @@
+class CreatePullRequestToIssueConnections < ActiveRecord::Migration
+  def change
+    create_table :pull_request_to_issue_connections do |t|
+      t.belongs_to :pull_request, :index => true
+
+      t.belongs_to :issue, :index => true
+
+      t.timestamps :null => false
+    end
+  end
+end

--- a/db/migrate/20160702105632_add_changelog_related_fields_to_projects.rb
+++ b/db/migrate/20160702105632_add_changelog_related_fields_to_projects.rb
@@ -1,0 +1,21 @@
+class AddChangelogRelatedFieldsToProjects < ActiveRecord::Migration
+  def change
+    add_column :projects, :include_issues, :boolean, :default => true, :null => false
+
+    add_column :projects, :include_pull_requests, :boolean, :default => true, :null => false
+
+    add_column :projects, :include_detailed_changes, :boolean, :default => true, :null => false
+
+    add_column :projects, :close_issues, :boolean, :default => false, :null => false
+
+    add_column :projects, :generate_changelogs, :boolean, :default => false, :null => false
+
+    add_column :projects, :emails_for_reports, :text, :array => true, :default => []
+
+    add_column :projects, :write_changelog_to_repository, :boolean, :default => false, :null => false
+
+    add_column :projects, :changelog_locale, :string, :default => 'en', :null => false
+
+    add_column :projects, :changelog_filename, :string, :default => 'CHANGELOG', :null => false
+  end
+end

--- a/db/migrate/20160704204218_create_pull_request_subtasks.rb
+++ b/db/migrate/20160704204218_create_pull_request_subtasks.rb
@@ -1,0 +1,19 @@
+class CreatePullRequestSubtasks < ActiveRecord::Migration
+  def change
+    create_table :pull_request_subtasks do |t|
+      t.belongs_to :pull_request, :index => true
+
+      t.belongs_to :changelog, :index => true
+
+      t.string :story_points
+
+      t.text :description, :null => false
+
+      t.string :task_type
+
+      t.jsonb :meta, :default => {}
+
+      t.timestamps :null => false
+    end
+  end
+end

--- a/lib/viewable.rb
+++ b/lib/viewable.rb
@@ -1,0 +1,16 @@
+module Viewable
+  extend ActiveSupport::Concern
+
+  private
+
+  def view
+    ActionView::Base.new(Rails.configuration.paths['app/views']).tap do |av|
+      av.class_eval do
+        include Rails.application.routes.url_helpers
+        include ApplicationHelper
+        include Devise::Controllers::Helpers
+        include CanCan::ControllerAdditions
+      end
+    end
+  end
+end

--- a/spec/controllers/changelogs_controller_spec.rb
+++ b/spec/controllers/changelogs_controller_spec.rb
@@ -1,0 +1,60 @@
+require 'rails_helper'
+
+RSpec.describe ChangelogsController, :type => :controller do
+  let(:user) { create :user }
+
+  let(:project) { create :project }
+
+  let(:changelog) { create :changelog, :project => project }
+
+  it { should route(:get, '/projects/1/changelogs').to(:action => :index, :project_id => 1) }
+
+  it { should route(:get, '/projects/1/changelogs/1').to(:action => :show, :project_id => 1, :id => 1) }
+
+  it do
+    should route(:get, '/projects/1/changelogs/1/resend').
+      to(:action => :resend, :project_id => 1, :id => 1)
+  end
+
+  it { should route(:get, '/projects/1/changelogs/sync').to(:action => :sync, :project_id => 1) }
+
+  context 'Confirmed user' do
+    before do
+      sign_in user
+
+      user.confirm
+
+      user.user_to_project_connections << (create :user_to_project_connection, :user => user, :project => project)
+    end
+
+    describe 'GET index' do
+      before { get :index, :project_id => project }
+
+      it { should render_template :index }
+    end
+
+    describe 'GET show' do
+      before { get :show, :project_id => project, :id => changelog }
+
+      it { should render_template :show }
+    end
+
+    describe 'GET show as TEXT' do
+      before { get :show, :project_id => project, :id => changelog, :format => :text }
+
+      it { should render_template 'changelogs/_changelog_raw_md' }
+    end
+
+    describe 'GET sync' do
+      before { get :sync, :project_id => project }
+
+      it { should redirect_to project_changelogs_url(assigns(:project)) }
+    end
+
+    describe 'GET resend' do
+      before { get :resend, :project_id => project, :id => changelog }
+
+      it { should redirect_to project_changelogs_url(assigns(:project)) }
+    end
+  end
+end

--- a/spec/controllers/projects_controller_spec.rb
+++ b/spec/controllers/projects_controller_spec.rb
@@ -83,7 +83,10 @@ RSpec.describe ProjectsController, :type => :controller do
 
   describe 'POST payload_from_bitbucket' do
     context 'when nothing payload' do
-      before { post :payload_from_bitbucket, :id => connection.project }
+      before do
+        post :payload_from_bitbucket, :id => connection.project,
+          :issue => { :title => 'bar', :content => { :raw => 'foo' } }
+      end
 
       it { expect(response.body).to be_blank }
     end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -9,6 +9,30 @@ FactoryGirl.define do
     locale 'en'
 
     name 'Test user'
+
+    trait :github_profile do
+      after(:create) do |user|
+        user.authentications << (create :authentication, :provider => 'github')
+      end
+    end
+
+    trait :gitlab_profile do
+      after(:create) do |user|
+        user.authentications << (create :authentication, :provider => 'gitlab', :gitlab_private_token => 'token')
+      end
+    end
+
+    trait :bitbucket_profile do
+      after(:create) do |user|
+        user.authentications << (create :authentication, :provider => 'bitbucket')
+      end
+    end
+
+    factory :user_with_github_profile, :traits => [:github_profile]
+
+    factory :user_with_gitlab_profile, :traits => [:gitlab_profile]
+
+    factory :user_with_bitbucket_profile, :traits => [:bitbucket_profile]
   end
 
   factory :authentication do
@@ -101,5 +125,35 @@ FactoryGirl.define do
     content 'Some content'
 
     email 'some@mail.com'
+  end
+
+  factory :changelog do
+    tag_name '1.0.0'
+
+    last_commit_sha '123456'
+
+    last_commit_date DateTime.now.utc
+
+    project
+  end
+
+  factory :pull_request do
+    merged_at DateTime.now.utc
+
+    title 'Some title'
+
+    changelog
+
+    project
+  end
+
+  factory :pull_request_to_issue_connection do
+    pull_request
+
+    issue
+  end
+
+  factory :pull_request_subtask do
+    pull_request
   end
 end

--- a/spec/mailers/previews/project_mailer_preview.rb
+++ b/spec/mailers/previews/project_mailer_preview.rb
@@ -1,0 +1,3 @@
+# Preview all emails at http://localhost:3000/rails/mailers/project_mailer
+class ProjectMailerPreview < ActionMailer::Preview
+end

--- a/spec/mailers/project_mailer_spec.rb
+++ b/spec/mailers/project_mailer_spec.rb
@@ -1,0 +1,40 @@
+require 'rails_helper'
+
+RSpec.describe ProjectMailer, :type => :mailer do
+  let(:project) { create :project, :emails_for_reports => ['test@mail.com'] }
+
+  let(:changelog) { create :changelog, :project => project }
+
+  let(:mail) { ProjectMailer.changelogs_email([changelog.id]) }
+
+  describe '#changelogs_email' do
+    context 'when single release' do
+      it 'renders the subject' do
+        expect(mail.subject).to eql('Some project release 1.0.0')
+      end
+    end
+
+    context 'when multiple releases' do
+      before do
+        @first = create :changelog, :project => project, :tag_name => '1.0.1',
+          :last_commit_date => DateTime.now.utc - 1.day
+
+        @second = create :changelog, :project => project, :tag_name => '2.0.0',
+          :last_commit_date => DateTime.now.utc
+      end
+
+      it 'renders the subject' do
+        expect(ProjectMailer.changelogs_email([@first.id, @second.id]).subject).
+          to eql('Some project releases 1.0.1 - 2.0.0')
+      end
+    end
+
+    it 'renders the receiver email' do
+      expect(mail.to).to eql(['test@mail.com'])
+    end
+
+    it 'renders the sender email' do
+      expect(mail.from).to eql(['info@kanbanonrails.com'])
+    end
+  end
+end

--- a/spec/models/changelog_spec.rb
+++ b/spec/models/changelog_spec.rb
@@ -1,0 +1,4 @@
+require 'rails_helper'
+
+RSpec.describe Changelog, :type => :model do
+end

--- a/spec/models/issue_spec.rb
+++ b/spec/models/issue_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe Issue, :type => :model do
     end
   end
 
-  describe '#sync_with_github' do
+  describe '#sync_with_gitlab' do
     context 'when new issue' do
       before do
         stub_request(:post, 'https://gitlab.com/api/v3/projects//issues').

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -24,4 +24,64 @@ RSpec.describe Project, :type => :model do
   describe '#open_issues' do
     it { expect(project.open_issues).to eq 0 }
   end
+
+  describe '#write_changelog' do
+    context 'when project is github repository' do
+      before do
+        user = create :user_with_github_profile
+
+        @project = create :project, :is_github_repository => true, :github_repository_id => 1,
+          :close_issues => true
+
+        create :user_to_project_connection, :user => user, :project => @project, :role => 'owner'
+
+        create :changelog, :project => @project
+
+        stub_request(:get, 'https://api.github.com/repositories/1/contents/CHANGELOG.md').
+          with(:headers => { 'Accept' => 'application/vnd.github.v3+json',
+            'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+            'Authorization' => 'token sometoken', 'Content-Type' => 'application/json',
+            'User-Agent' => 'Octokit Ruby Gem 4.3.0' }).
+          to_return(
+            :status => 200, :headers => { 'Content-Type' => 'application/json' },
+            :body => {
+              :sha => '123456'
+            }.to_json
+          )
+
+        stub_request(:put, 'https://api.github.com/repositories/1/contents/CHANGELOG.md').
+          with(:body => /.*/, :headers => { 'Accept' => 'application/vnd.github.v3+json',
+            'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+            'Authorization' => 'token sometoken', 'Content-Type' => 'application/json',
+            'User-Agent' => 'Octokit Ruby Gem 4.3.0' }).
+          to_return(:status => 200, :body => '', :headers => {})
+      end
+
+      it { expect(@project.write_changelog).to eq '' }
+    end
+
+    context 'when project is gitlab repository' do
+      before do
+        user = create :user_with_gitlab_profile
+
+        @project = create :project, :is_gitlab_repository => true, :gitlab_repository_id => 1,
+          :close_issues => true
+
+        create :user_to_project_connection, :user => user, :project => @project, :role => 'owner'
+
+        create :changelog, :project => @project
+
+        stub_request(:get,
+          'https://gitlab.com/api/v3/projects/1/repository/files?file_path=CHANGELOG.md&ref=master').
+          with(:headers => { 'Accept' => 'application/json', 'Private-Token' => 'token' }).
+          to_return(:status => 200, :body => '', :headers => {})
+
+        stub_request(:put, 'https://gitlab.com/api/v3/projects/1/repository/files').
+          with(:body => /.*/, :headers => { 'Accept' => 'application/json', 'Private-Token' => 'token' }).
+          to_return(:status => 200, :body => '', :headers => {})
+      end
+
+      it { expect(@project.write_changelog).to eq false }
+    end
+  end
 end

--- a/spec/models/pull_request_spec.rb
+++ b/spec/models/pull_request_spec.rb
@@ -1,0 +1,4 @@
+require 'rails_helper'
+
+RSpec.describe PullRequest, :type => :model do
+end

--- a/spec/models/pull_request_subtask_spec.rb
+++ b/spec/models/pull_request_subtask_spec.rb
@@ -1,0 +1,4 @@
+require 'rails_helper'
+
+RSpec.describe PullRequestSubtask, :type => :model do
+end

--- a/spec/models/pull_request_to_issue_connection_spec.rb
+++ b/spec/models/pull_request_to_issue_connection_spec.rb
@@ -1,0 +1,4 @@
+require 'rails_helper'
+
+RSpec.describe PullRequestToIssueConnection, :type => :model do
+end

--- a/spec/services/generate_changelogs_spec.rb
+++ b/spec/services/generate_changelogs_spec.rb
@@ -1,0 +1,153 @@
+require 'rails_helper'
+
+RSpec.describe GenerateChangelogs do
+  describe '#handle_changelogs' do
+    context 'when project is the github repository' do
+      before do
+        @user = create :user_with_github_profile
+
+        project = create :project, :is_github_repository => true, :github_repository_id => 1,
+          :close_issues => true
+
+        create :issue, :github_issue_number => 1, :project => project
+
+        create :user_to_project_connection, :user => @user, :project => project, :role => 'owner'
+
+        stub_request(:get, 'https://api.github.com/repos/some/project/tags?per_page=100').
+          with(:headers => { 'Accept' => 'application/vnd.github.v3+json',
+            'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+            'Authorization' => 'token sometoken', 'Content-Type' => 'application/json',
+            'User-Agent' => 'Octokit Ruby Gem 4.3.0' }).
+          to_return(:status => 200, :headers => {}, :body => [
+            Hashie::Mash.new(
+              :commit => { :sha => '123456', :author => { :date => DateTime.now.utc } },
+              :name => '0.0.1'
+            )
+          ])
+
+        stub_request(:get, 'https://api.github.com/repositories/1/commits/123456').
+          with(:headers => { 'Accept' => 'application/vnd.github.v3+json',
+            'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+            'Authorization' => 'token sometoken', 'Content-Type' => 'application/json',
+            'User-Agent' => 'Octokit Ruby Gem 4.3.0' }).
+          to_return(
+            :status => 200, :headers => { 'Content-Type' => 'application/json' },
+            :body => {
+              :commit => { :sha => '123456', :author => { :date => DateTime.now.utc } },
+              :name => '0.0.1'
+            }.to_json
+          )
+
+        stub_request(:get, 'https://api.github.com/repos/some/project/pulls?per_page=100&state=closed').
+          with(:headers => { 'Accept' => 'application/vnd.github.v3+json',
+            'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+            'Authorization' => 'token sometoken', 'Content-Type' => 'application/json',
+            'User-Agent' => 'Octokit Ruby Gem 4.3.0' }).
+          to_return(:status => 200, :headers => {}, :body => [
+            Hashie::Mash.new(
+              :title => 'some title',
+              :body => "1. [new][S] Some feature\nconnects to #1\nconnects to #2",
+              :merged_at => DateTime.now.utc,
+              :html_url => 'https://some.url',
+              :id => 1,
+              :user => { :login => 'login' }
+            )
+          ])
+
+        stub_request(:get, 'https://api.github.com/repositories/1/issues/2').
+          with(:headers => { 'Accept' => 'application/vnd.github.v3+json',
+            'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+            'Authorization' => 'token sometoken', 'Content-Type' => 'application/json',
+            'User-Agent' => 'Octokit Ruby Gem 4.3.0' }).
+          to_return(
+            :status => 200, :headers => { 'Content-Type' => 'application/json' },
+            :body => {
+              :title => 'Some title',
+              :body => 'Some body',
+              :labels => []
+            }.to_json
+          )
+      end
+
+      it { expect(GenerateChangelogs.new(:project => @user.projects.first).handle_changelogs).to eq 1 }
+    end
+
+    context 'when project is the gitlab repository' do
+      before do
+        @user = create :user_with_gitlab_profile
+
+        project = create :project, :is_gitlab_repository => true, :gitlab_repository_id => 1,
+          :close_issues => true
+
+        create :issue, :gitlab_issue_number => 1, :project => project
+
+        create :user_to_project_connection, :user => @user, :project => project, :role => 'owner'
+
+        stub_request(:get, 'https://gitlab.com/api/v3/projects/1/repository/tags').
+          with(:headers => { 'Accept' => 'application/json', 'Private-Token' => 'token' }).
+          to_return(:status => 200, :headers => {}, :body => [{
+            :name => 'name',
+            :commit => { 'id' => 1, :committed_date => DateTime.now.utc }
+          }].to_json)
+
+        stub_request(:get, 'https://gitlab.com/api/v3/projects/1/merge_requests?state=merged').
+          with(:headers => { 'Accept' => 'application/json', 'Private-Token' => 'token' }).
+          to_return(:status => 200, :headers => {}, :body => [{
+            :id => 1,
+            :iid => 1,
+            :updated_at => DateTime.now.utc,
+            :title => 'Some feature',
+            :description => "1. [new][S] Some feature\nconnects to #1",
+            :author => { :username => 'username', :weburl => 'https://some.url' }
+          }].to_json)
+      end
+
+      it { expect(GenerateChangelogs.new(:project => @user.projects.first).handle_changelogs).to eq 1 }
+    end
+
+    context 'when project is the bitbucket repository' do
+      before do
+        @user = create :user_with_bitbucket_profile
+
+        project = create :project, :is_bitbucket_repository => true, :bitbucket_slug => 'foo',
+          :bitbucket_owner => 'bar', :close_issues => true
+
+        create :issue, :bitbucket_issue_number => 1, :project => project
+
+        create :user_to_project_connection, :user => @user, :project => project, :role => 'owner'
+
+        stub_request(:get, 'https://api.bitbucket.org/1.0/repositories/bar/foo/tags/').
+          with(:headers => { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+            'Authorization' => /.*/, 'Content-Type' => 'application/json',
+            'User-Agent' => 'BitBucket Ruby Gem 0.1.7' }).
+          to_return(:status => 200, :headers => {}, :body => [['0.0.1', {
+            :utctimestamp => DateTime.now.utc,
+            :raw_node => '123456'
+          }]].to_json)
+
+        stub_request(:get, 'https://api.bitbucket.org/2.0/repositories/bar/foo/pullrequests?state=merged').
+          with(:headers => { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+            'Authorization' => /.*/, 'Content-Type' => 'application/json',
+            'User-Agent' => 'BitBucket Ruby Gem 0.1.7' }).
+          to_return(:status => 200, :headers => {}, :body => {
+            :values => [
+              :title => 'Some title',
+              :id => 1,
+              :description => "1. [new][S] Some feature\nconnects to #1",
+              :merge_commit => { :hash => '123456' },
+              :author => { :username => 'username', :links => { :html => { :href => 'https://some.url' } } },
+              :links => { :html => { :href => 'https://some.url' } }
+            ]
+          }.to_json)
+
+        stub_request(:get, 'https://api.bitbucket.org/2.0/repositories/bar/foo/commit/123456').
+          with(:headers => { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+            'Authorization' => /.*/, 'Content-Type' => 'application/json',
+            'User-Agent' => 'BitBucket Ruby Gem 0.1.7' }).
+          to_return(:status => 200, :body => { :date => DateTime.now.utc }.to_json, :headers => {})
+      end
+
+      it { expect(GenerateChangelogs.new(:project => @user.projects.first).handle_changelogs).to eq 1 }
+    end
+  end
+end

--- a/spec/workers/generate_changelog_worker_spec.rb
+++ b/spec/workers/generate_changelog_worker_spec.rb
@@ -1,0 +1,9 @@
+require 'rails_helper'
+
+RSpec.describe GenerateChangelogWorker do
+  let(:project) { create :project, :is_github_repository => true }
+
+  describe '#perform' do
+    it { expect(GenerateChangelogWorker.new.perform(project.id)).to eq nil }
+  end
+end


### PR DESCRIPTION
1. [new][L] User now can receive automatically built changelogs and automatically write it to repository. Service also have ability to automatically close issues that bound to pull requests. All changelogs are built in accord with git tags and can include pull requests, detailed description in pull requests(subtasks) and issues bound(with special words such as "connects to #...", "fix #..." and so on) to that pull requests. 

connects to #13