### PR TITLE
Fix to run changelog worker in the changelogs controller

### DIFF
--- a/app/controllers/changelogs_controller.rb
+++ b/app/controllers/changelogs_controller.rb
@@ -25,7 +25,7 @@ class ChangelogsController < ApplicationController
   end
 
   def sync
-    GenerateChangelogWorker.perform_async(@project)
+    GenerateChangelogWorker.perform_async(@project.id)
 
     redirect_to project_changelogs_url, :flash => { :notice => I18n.t('changelogs_has_been_synced') }
   end


### PR DESCRIPTION
1. [bug][S] It would better to use id instead of object when running a worker