### PR TITLE
Change to "warn" the rule about double quotes in coffelint

### DIFF
--- a/app/assets/javascripts/counters.coffee
+++ b/app/assets/javascripts/counters.coffee
@@ -2,4 +2,4 @@ jQuery ->
   $(document).on 'page:change', ->
     if window.ga?
       ga('set',  'location', location.href.split('#')[0])
-      ga('send', 'pageview', { "title": document.title })
+      ga('send', 'pageview', { 'title': document.title })

--- a/coffeelint.json
+++ b/coffeelint.json
@@ -111,7 +111,7 @@
     "allowed_in_empty_lines": true
   },
   "no_unnecessary_double_quotes": {
-    "level": "ignore"
+    "level": "warn"
   },
   "no_unnecessary_fat_arrows": {
     "level": "warn"


### PR DESCRIPTION
1. [ref][S] Now it creates warning when there is a double unnecessary quotes in coffescript files