### PR TITLE
Add fasterer for lint and dry for travis script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,7 @@ install:
   - npm install
   - bundle install
 script:
-  - bundle exec rake spec
-  - bundle exec rubocop -c .rubocop.yml
-  - bundle exec rails_best_practices
-  - bundle exec brakeman
-  - npm run sass-lint
-  - npm run coffeelint
+  - bundle exec rake kanban_on_rails:run_all_specs_and_lints
 services:
   - postgresql
   - redis-server

--- a/app/models/concerns/empty_array_removable.rb
+++ b/app/models/concerns/empty_array_removable.rb
@@ -8,7 +8,7 @@ module EmptyArrayRemovable
   private
 
   def remove_empty_arrays
-    attributes.keys.each do |attribute|
+    attributes.each_key do |attribute|
       if self[attribute].is_a?(Array) && self[attribute].present?
         self[attribute] = self[attribute].reject(&:blank?)
       end

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -24,10 +24,10 @@ set :deploy_to, '/home/deployer/kanbanonrails'
 # set :pty, true
 
 # Default value for :linked_files is []
-set :linked_files, fetch(:linked_files, []).push('config/settings.local.yml')
+set :linked_files, fetch(:linked_files) { [] }.push('config/settings.local.yml')
 
 # Default value for linked_dirs is []
-set :linked_dirs, fetch(:linked_dirs, []).push('bin', 'log', 'tmp/pids',
+set :linked_dirs, fetch(:linked_dirs) { [] }.push('bin', 'log', 'tmp/pids',
   'tmp/cache', 'tmp/sockets', 'vendor/bundle', 'public/system', 'public/assets')
 
 set :bundle_binstubs, -> { shared_path.join('bin') }

--- a/lib/tasks/kanban_on_rails.rake
+++ b/lib/tasks/kanban_on_rails.rake
@@ -9,6 +9,8 @@ namespace :kanban_on_rails do
 
     sh('bundle exec brakeman')
 
+    sh('bundle exec fasterer')
+
     sh('npm run coffeelint')
 
     sh('npm run sass-lint')


### PR DESCRIPTION
1. [ref][S] Add fasterer for lint
2. [ref][S] Remove script duplication for lint and tests in travis, now it runs with just one command rake kanban_on_rails:run_all_specs_and_lints   